### PR TITLE
[ch25380] [etools-currency-amount-input] Cursor jumps during editing, if the number has decimals

### DIFF
--- a/etools-currency-amount-input.js
+++ b/etools-currency-amount-input.js
@@ -302,7 +302,7 @@ class EtoolsCurrencyAmountInput extends EtoolsCurrency(PolymerElement) {
     const numberAddedWithDelimiter = diff > 1;
     const numberRemovedWithDelimiter = diff < -1;
     const cursorIsNotFirst = cursorPos > 1;
-    const cursorIsNotLast = cursorPos < oldValueLength;
+    const cursorIsNotLast = cursorPos < valueLength;
 
     if(numberAddedWithDelimiter && cursorIsNotFirst) {
       cursorPos++;


### PR DESCRIPTION
[ch25380] [etools-currency-amount-input] Cursor jumps during editing, if the number has decimals