### PR TITLE
[ch31796] etools-currency-amount-input component- exclude src_ts folder from published version of package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -8,4 +8,5 @@ test/
 .eslintingore
 .eslintrc.json
 .prettierrc
-analysis.json 
+analysis.json
+src_ts/

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@unicef-polymer/etools-currency-amount-input",
-  "version": "4.0.2",
+  "version": "4.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "description": "A paper-input element that allows only currency amount values. US currency format only.",
   "name": "@unicef-polymer/etools-currency-amount-input",
-  "version": "4.0.2",
+  "version": "4.0.3",
   "homepage": "https://github.com/unicef-polymer/etools-currency-amount-input",
   "repository": {
     "type": "git",


### PR DESCRIPTION
[ch31796] etools-currency-amount-input component- exclude src_ts folder from published version of package